### PR TITLE
fix rsync error for unsafe symlinks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,9 @@ Vagrant.configure("2") do |config|
     echo -e "[Main]\nProduct=Rocky Linux\nVersion=8" > /.buildstamp
     setenforce 0
   SHELL
-  config.vm.synced_folder "anaconda/", "/usr/share/anaconda/",type: "rsync"
+  config.vm.synced_folder "anaconda/", "/usr/share/anaconda/",
+    type: "rsync",
+    rsync__args: ["--copy-unsafe-links"]
+
   config.vm.synced_folder ".", "/vagrant", disabled: true
 end


### PR DESCRIPTION
When we try to sync anaconda files with vagrant, below error happend.

(but not happend first/init running)

```
Error: symlink has no referent: "/home/hayden/code/rocky/rocky-build-box/anaconda/window-manager/glib-2.0/schemas/org.gnome.metacity.gschema.xml"
```

rsync does not allow to sync unsafe links as default so we need to add `--copy-unsafe-links` options to resolve that :smile: 

Signed-off-by: Ji-Hyeon Gim <potatogim@gluesys.com>